### PR TITLE
Implement support for specifying the Redis DB

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,7 @@ tsuru_api_sentinels:
     master: ""
     address: ""
     password: ""
+    db: 0
 
 # Tsuru Simple Redis Confs
 tsuru_api_redis_address: ""

--- a/templates/tsuru.conf.j2
+++ b/templates/tsuru.conf.j2
@@ -59,11 +59,12 @@ routers:
     type: {{ tsuru_router.type }}
     domain: {{ tsuru_router.domain }}
 {% if tsuru_router.sentinel_enabled %}
-{% for tsuru_sentinel in tsuru_sentinels %}
+{% for tsuru_sentinel in tsuru_api_sentinels %}
 {% if tsuru_sentinel.name == tsuru_router.sentinel_name %}
     redis-sentinel-addrs: {{ tsuru_sentinel.address }}
     redis-sentinel-master: {{ tsuru_sentinel.master|default(tsuru_api_sentinel_master_all) }}
     redis-password: {{ tsuru_sentinel.password|default(tsuru_api_sentinel_password_all) }}
+    redis-db: {{ tsuru_sentinel.db|default(0) }}
 {% endif %}
 {% endfor %}
 {% else %}


### PR DESCRIPTION
This change should enable the specification of the Redis DB to be used by the Tsuru API.